### PR TITLE
Disable creating v4-non-ukb lists

### DIFF
--- a/frontend/src/components/CreateVariantListPage/CustomVariantListForm.tsx
+++ b/frontend/src/components/CreateVariantListPage/CustomVariantListForm.tsx
@@ -128,14 +128,13 @@ const CustomVariantListForm = () => {
             <RadioGroup value={gnomadVersion} onChange={setGnomadVersion}>
               <VStack align="flex-start">
                 <Radio value="4.0.0">4.0.0 (GRCh38)</Radio>
-                <Radio value="4.0.0_non-ukb">4.0.0 - Non-UKB (GRCh38)</Radio>
                 <Radio value="2.1.1">2.1.1 (GRCh37)</Radio>
               </VStack>
             </RadioGroup>
 
             <FormHelperText>
               <Link
-                href="https://gnomad.broadinstitute.org/help/whats-the-difference-between-gnomad-v2-and-v3"
+                href="https://gnomad.broadinstitute.org/help/whats-the-difference-between-the-different-versions-of-gnomad"
                 isExternal
               >
                 What's the difference between gnomAD v2 and v3?

--- a/frontend/src/components/CreateVariantListPage/RecommendedVariantListForm.tsx
+++ b/frontend/src/components/CreateVariantListPage/RecommendedVariantListForm.tsx
@@ -136,14 +136,13 @@ const RecommendedVariantListForm = () => {
           >
             <VStack align="flex-start">
               <Radio value="4.0.0">4.0.0 (GRCh38)</Radio>
-              <Radio value="4.0.0_non-ukb">4.0.0 - Non-UKB (GRCh38)</Radio>
               <Radio value="2.1.1">2.1.1 (GRCh37)</Radio>
             </VStack>
           </RadioGroup>
 
           <FormHelperText>
             <Link
-              href="https://gnomad.broadinstitute.org/help/whats-the-difference-between-gnomad-v2-and-v3"
+              href="https://gnomad.broadinstitute.org/help/whats-the-difference-between-the-different-versions-of-gnomad"
               isExternal
             >
               What's the difference between gnomAD v2 and v3?

--- a/frontend/src/components/VariantListPage/VariantsTable.tsx
+++ b/frontend/src/components/VariantListPage/VariantsTable.tsx
@@ -159,6 +159,7 @@ const BASE_COLUMNS: ColumnDef[] = [
       const gnomadDataset = {
         "2.1.1": "gnomad_r2_1",
         "3.1.2": "gnomad_r3",
+        "4.0.0": "gnomad_r4",
       }[gnomadVersion];
 
       return (


### PR DESCRIPTION
- Removes option from frontend to create v4-non-ukb lists for now until that data is properly handles
- Updates v4 variant lists links to gnomad browser
- Updates help text link