### PR TITLE
Allow custom variant list for GRCh38

### DIFF
--- a/worker/src/worker/tasks.py
+++ b/worker/src/worker/tasks.py
@@ -358,7 +358,10 @@ def _process_variant_list(variant_list):
     # Import existing variants into a Hail Table
     ds = None
     if variant_list.variants:
-        variant_ids = [variant["id"] for variant in variant_list.variants]
+        chrom_prefix = "" if gnomad_version == "2.1.1" else "chr"
+        variant_ids = [
+            f"{chrom_prefix}{variant['id']}" for variant in variant_list.variants
+        ]
         ds = hl.Table.parallelize(
             [{"id": variant_id} for variant_id in variant_ids], hl.tstruct(id=hl.tstr)
         )


### PR DESCRIPTION
Resolves #177 

Custom variant lists use a function from `@gnomad/identifiers` to normalize the variant ID. With GRCh38, hail expects contig values to be formatted as "chr1" rather than "1" for example

This is a very small PR that checks the reference genome (by proxy of gnomad_version in the request) and appends "chr" onto contigs as needed for variant lists created with a GRCh38 gnomad dataset.

---

This was tested locally in my dev instance, and results in a list being successfully created, rather than hail raising an error that gets reported to the user on the frontend.