### PR TITLE
Fix updating of lists created before the inclusion of the high revel score flag

### DIFF
--- a/worker/src/worker/tasks.py
+++ b/worker/src/worker/tasks.py
@@ -254,14 +254,17 @@ def get_recommended_variants(metadata, transcript):
     ds = ds.transmute(**ds.transcript_consequence)
 
     # TODO: add a test for this
-    if not metadata["include_gnomad_missense_with_high_revel_score"]:
-        include_from_gnomad = PLOF_VEP_CONSEQUENCE_TERMS.contains(
-            ds.major_consequence
-        ) & (ds.lof == "HC")
-    else:
+    if (
+        "include_gnomad_missense_with_high_revel_score" in metadata.keys()
+        and metadata["include_gnomad_missense_with_high_revel_score"]
+    ):
         include_from_gnomad = (
             PLOF_VEP_CONSEQUENCE_TERMS.contains(ds.major_consequence) & (ds.lof == "HC")
         ) | ((ds.major_consequence == "missense_variant") & (ds.revel_score >= 9.32e-1))
+    else:
+        include_from_gnomad = PLOF_VEP_CONSEQUENCE_TERMS.contains(
+            ds.major_consequence
+        ) & (ds.lof == "HC")
 
     ds = ds.annotate(include_from_gnomad=include_from_gnomad)
 


### PR DESCRIPTION
Fixes a bug in which lists created before the option to include missense variants with a high revel score would be unable to update the list when adding more variants.

The background worker previously checked if the flag to include missense with high revel scores flags was true, thus if a list was created before this flag would added the code would throw a key error. This is a small update that adds a check first if the key exists, then if so if the key is set to True, to prevent the crash.