### PR TITLE
Remove pyspark env vars set in worker dockerfile

### DIFF
--- a/worker/worker.dockerfile
+++ b/worker/worker.dockerfile
@@ -10,9 +10,6 @@ WORKDIR /app
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
 
-# pass more memory to pyspark via setting environment variables
-ENV PYSPARK_SUBMIT_ARGS="--driver-memory 1g --executor-memory 3g"
-
 # Install dependencies
 RUN apt-get -qq update && \
   apt-get -qq install gnupg software-properties-common wget && \


### PR DESCRIPTION
Remove the pyspark ENV vars set in the worker dockerfile in favor of including them in the worker cloud run yaml.