### PR TITLE
Update flags passed to gunicorn in worker dockerfile

### DIFF
--- a/worker/worker.dockerfile
+++ b/worker/worker.dockerfile
@@ -55,4 +55,4 @@ USER app
 # Run
 ENV DJANGO_SETTINGS_MODULE=worker.settings.base
 
-CMD exec gunicorn --bind :$PORT --log-file - --workers 1 --threads 8 worker.wsgi
+CMD exec gunicorn --bind :$PORT --log-file - --workers 1 --threads 8 --timeout 120 --preload worker.wsgi


### PR DESCRIPTION
Update flags passed to gunicorn to include:
- `--timeout 120`, looking at logs when the worker first starts up reveals many worker processes being killed by Gunicorn when they don't respond in time (I think). Upping this parameter to be above the default (30s) should allow the first process spawned when Google Cloud Run scales up to successfully spin up and handle the http request
- `--preload` passing this flag _should_ help with initial startup time.