### PR TITLE
Temporarily allow staff to edit any list

### DIFF
--- a/website/src/website/views/variant_list_views.py
+++ b/website/src/website/views/variant_list_views.py
@@ -144,7 +144,7 @@ class VariantListView(RetrieveUpdateDestroyAPIView):
 
     def patch(self, request, *args, **kwargs):
         instance = self.get_object()
-        if (
+        if not self.request.user.is_staff and (
             not self.request.user.has_perm("calculator.change_variantlist", instance)
             or "public_status" in request.data
         ):


### PR DESCRIPTION
Temporarily allow staff to edit any list so that staff can edit gene id and transcript and reprocess lists affected by v4 custom list bug. Will be reverted once the lists are corrected.