### PR TITLE
Allow staff to trigger reprocessing of any list

### DIFF
--- a/website/src/website/views/variant_list_views.py
+++ b/website/src/website/views/variant_list_views.py
@@ -183,9 +183,15 @@ class VariantListProcessView(GenericAPIView):
 
     lookup_field = "uuid"
 
-    permission_classes = (IsAuthenticated, VariantListProcessViewObjectPermissions)
+    permission_classes = (IsAuthenticated,)
 
     def post(self, request, *args, **kwargs):  # pylint: disable=unused-argument
+        instance = self.get_object()
+        if not self.request.user.is_staff and not self.request.user.has_perm(
+            "calculator.change_variantlist", instance
+        ):
+            raise PermissionDenied
+
         variant_list = self.get_object()
 
         publisher.send_to_worker(

--- a/website/tests/views/test_variant_list_views.py
+++ b/website/tests/views/test_variant_list_views.py
@@ -898,9 +898,9 @@ class TestProcessVariantList:
             ("viewer", 403),
             ("editor", 200),
             ("owner", 200),
-            ("other", 404),
+            ("other", 403),
             ("inactiveuser", 403),
-            ("staffmember", 403),
+            ("staffmember", 200),
         ],
     )
     def test_process_variant_list_requires_permission(self, user, expected_response):


### PR DESCRIPTION
Modifies the existing endpoint to allow staff to trigger a reprocessing of any variant list