### PR TITLE
Remove redundant process endpoint and view

### DIFF
--- a/website/src/website/urls.py
+++ b/website/src/website/urls.py
@@ -8,7 +8,6 @@ from website.views.user_views import UsersList, UserDetail
 from website.views.variant_list_views import (
     VariantListsView,
     VariantListView,
-    VariantListUpdateView,
     VariantListAnnotationView,
     VariantListSharedAnnotationView,
     VariantListProcessView,
@@ -69,11 +68,6 @@ urlpatterns = [
         "api/variant-lists/<uuid:uuid>/variants/",
         VariantListVariantsView.as_view(),
         name="variant-list-variants",
-    ),
-    path(
-        "api/variant-lists/<uuid:uuid>/variants/update",
-        VariantListUpdateView.as_view(),
-        name="variant-list-reprocess",
     ),
     path(
         "api/variant-list-access/",

--- a/website/src/website/views/variant_list_views.py
+++ b/website/src/website/views/variant_list_views.py
@@ -6,14 +6,12 @@ from rest_framework.generics import (
     GenericAPIView,
     ListAPIView,
     ListCreateAPIView,
-    RetrieveAPIView,
     RetrieveUpdateAPIView,
     RetrieveUpdateDestroyAPIView,
 )
 from rest_framework.permissions import (
     DjangoObjectPermissions,
     IsAuthenticated,
-    IsAdminUser,
     IsAuthenticatedOrReadOnly,
 )
 from rest_framework.response import Response
@@ -69,29 +67,6 @@ class VariantListsView(ListCreateAPIView):
         publisher.send_to_worker(
             {"type": "process_variant_list", "args": {"uuid": str(variant_list.uuid)}}
         )
-
-    def get_success_headers(self, data):
-        try:
-            return {"Location": f"/api/variant-lists/{data['uuid']}/"}
-        except KeyError:
-            return {}
-
-
-class VariantListUpdateView(RetrieveAPIView):
-    queryset = VariantList.objects.all()
-
-    lookup_field = "uuid"
-
-    permission_classes = (IsAuthenticated, IsAdminUser)
-
-    serializer_class = VariantListSerializer
-
-    def get(self, request, *args, **kwargs):
-        instance = self.get_object()
-        publisher.send_to_worker(
-            {"type": "process_variant_list", "args": {"uuid": str(instance.uuid)}}
-        )
-        return self.retrieve(request, *args, **kwargs)
 
     def get_success_headers(self, data):
         try:

--- a/website/tests/views/test_variant_list_views.py
+++ b/website/tests/views/test_variant_list_views.py
@@ -355,7 +355,7 @@ class TestGetVariantList:
             level=VariantListAccessPermission.Level.OWNER,
         )
 
-        list11 = VariantList.objects.create(
+        VariantList.objects.create(
             id=11,
             label="Public List 1",
             type=VariantList.Type.CUSTOM,
@@ -368,12 +368,6 @@ class TestGetVariantList:
             public_status=VariantList.PublicStatus.APPROVED,
             public_status_updated_by=staffuser,
             variants=[{"id": "1-55516888-G-GA"}],
-        )
-
-        VariantListAccessPermission.objects.create(
-            user=testuser,
-            variant_list=list11,
-            level=VariantListAccessPermission.Level.EDITOR,
         )
 
         VariantList.objects.create(
@@ -527,39 +521,6 @@ class TestGetVariantList:
         # Staff members whoare inactive can only view public lists
         client.force_authenticate(User.objects.get(username="inactivestaff"))
         response = client.get(f"/api/variant-lists/{variant_list.uuid}/")
-        assert response.status_code == expected_response
-
-    def test_reprocessing_variant_list_requires_authentication(self):
-        variant_list = VariantList.objects.get(id=11)
-        client = APIClient()
-        response = client.get(f"/api/variant-lists/{variant_list.uuid}/variants/update")
-        assert response.status_code == 403
-
-    @pytest.mark.parametrize(
-        "username, list_id, expected_response",
-        [
-            ("anon", 11, 403),
-            ("anon", 12, 403),
-            ("anon", 13, 403),
-            ("testuser", 11, 403),
-            ("testuser", 12, 403),
-            ("testuser", 13, 403),
-            # Currently, re-processing can only be triggered by staff members
-            ("staffmember", 11, 200),
-            ("staffmember", 12, 200),
-            ("staffmember", 13, 200),
-        ],
-    )
-    def test_reprocessing_variant_list_requires_permission(
-        self, username, list_id, expected_response
-    ):
-        variant_list = VariantList.objects.get(id=list_id)
-        client = APIClient()
-
-        if username != "anon":
-            client.force_authenticate(User.objects.get(username=username))
-
-        response = client.get(f"/api/variant-lists/{variant_list.uuid}/variants/update")
         assert response.status_code == expected_response
 
 


### PR DESCRIPTION
Removes a redundant endpoint and view mistakenly introduced by me, the staff member re-process button now uses the existing "process" endpoint.