### PR TITLE
Rename 'Latino/Admixed American' labeling to 'Admixed American'

### DIFF
--- a/frontend/src/constants/populations.ts
+++ b/frontend/src/constants/populations.ts
@@ -6,7 +6,7 @@ export const GNOMAD_POPULATION_NAMES: {
   global: "Global",
   afr: "African/African-American",
   ami: "Amish",
-  amr: "Latino/Admixed American",
+  amr: "Admixed American",
   asj: "Ashkenazi Jewish",
   eas: "East Asian",
   "eas/jpn": "Japanese",


### PR DESCRIPTION
resolves #285

Renames the naming for the Admixed American genetic ancestry group from "Latino/Admixed American" to "Admixed American"