### PR TITLE
Rename "Global" to "Total" in genetic ancestry groups for carrier frequency and genetic prevalence estimates

### DIFF
--- a/frontend/src/constants/populations.ts
+++ b/frontend/src/constants/populations.ts
@@ -3,7 +3,7 @@ import { GnomadPopulationId } from "../types";
 export const GNOMAD_POPULATION_NAMES: {
   [key in GnomadPopulationId]: string;
 } = {
-  global: "Global",
+  global: "Total",
   afr: "African/African-American",
   ami: "Amish",
   amr: "Admixed American",


### PR DESCRIPTION
One liner, fixes #297 
<img width="997" alt="Screenshot 2024-10-15 at 2 48 44 PM" src="https://github.com/user-attachments/assets/1cc073a4-9aa3-4b37-a182-53774f5d93e1">
