### PR TITLE
Use numeric sort on appropriate columns

### DIFF
--- a/frontend/src/components/VariantListPage/VariantsTable.tsx
+++ b/frontend/src/components/VariantListPage/VariantsTable.tsx
@@ -657,14 +657,17 @@ const VariantsTable: FC<VariantsTableProps> = ({
     shouldShowVariant(variant)
   );
 
-  const sortedVariants = sortBy(visibleVariants, (variant) => [
-    notIncludedVariants && notIncludedVariants.has(variant.id) ? 0 : 1,
-    sortColumn.sortKey!(variant, variantList),
-  ]);
+  const intermediateSortedVariants = sortBy(visibleVariants, (variant) =>
+    sortColumn.sortKey!(variant, variantList)
+  );
 
   if (sortOrder === "descending") {
-    sortedVariants.reverse();
+    intermediateSortedVariants.reverse();
   }
+
+  const sortedVariants = sortBy(intermediateSortedVariants, (variant) =>
+    notIncludedVariants && notIncludedVariants.has(variant.id) ? 1 : 0
+  );
 
   const ROW_HEIGHT = isTopTen ? 35 : 70;
   const ITEMS_DISPLAYED = isTopTen ? 10 : 15;


### PR DESCRIPTION
Resolves #300 

Breaks up the sort function into two separate steps to achieve two things:
1. Fix the primary issue. It turns out that when `Lodash`'s `sortBy` helper function is given an array, it treats the arguments as a lexicographical sort, this PR splits up the two sort criteria in the array into separate steps to keep our `sortKey` pattern functional and make the columns sort numerically, as intended
2. Sorts the not included variants to the bottom of the the list after reversing, keeping them always at the bottom, rather than at the top half the time.