### PR TITLE
feat(frontend): allow filtering variant table on ID

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2942,6 +2942,15 @@
         "@types/react": "*"
       }
     },
+    "@types/react-highlight-words": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@types/react-highlight-words/-/react-highlight-words-0.20.0.tgz",
+      "integrity": "sha512-Qm512TiOakvtNzHJ2+TNVHnLn5cJ2wLQV0+LrhuispVth6dRf5b8ydjq3Kc0thpZ7bz4s6RnG6meboAXHWRK+Q==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*"
+      }
+    },
     "@types/react-router": {
       "version": "5.1.14",
       "resolved": "https://registry.npmjs.org/@types/react-router/-/react-router-5.1.14.tgz",
@@ -8093,6 +8102,11 @@
       "resolved": "https://registry.npmjs.org/hey-listen/-/hey-listen-1.0.8.tgz",
       "integrity": "sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q=="
     },
+    "highlight-words-core": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/highlight-words-core/-/highlight-words-core-1.2.3.tgz",
+      "integrity": "sha512-m1O9HW3/GNHxzSIXWw1wCNXXsgLlxrP0OI6+ycGUhiUHkikqW3OrwVHz+lxeNBe5yqLESdIcj8PowHQ2zLvUvQ=="
+    },
     "history": {
       "version": "4.10.1",
       "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
@@ -12924,6 +12938,23 @@
         "react-clientside-effect": "^1.2.2",
         "use-callback-ref": "^1.2.1",
         "use-sidecar": "^1.0.1"
+      }
+    },
+    "react-highlight-words": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/react-highlight-words/-/react-highlight-words-0.20.0.tgz",
+      "integrity": "sha512-asCxy+jCehDVhusNmCBoxDf2mm1AJ//D+EzDx1m5K7EqsMBIHdZ5G4LdwbSEXqZq1Ros0G0UySWmAtntSph7XA==",
+      "requires": {
+        "highlight-words-core": "^1.2.0",
+        "memoize-one": "^4.0.0",
+        "prop-types": "^15.5.8"
+      },
+      "dependencies": {
+        "memoize-one": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-4.0.3.tgz",
+          "integrity": "sha512-QmpUu4KqDmX0plH4u+tf0riMc1KHE1+lw95cMrLlXQAFOx/xnBtwhZ52XJxd9X2O6kwKBqX32kmhbhlobD0cuw=="
+        }
       }
     },
     "react-is": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,6 +30,7 @@
     "qs": "^6.10.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
+    "react-highlight-words": "^0.20.0",
     "react-multi-select-component": "^4.3.4",
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.3",
@@ -37,6 +38,7 @@
     "typescript": "^4.1.2"
   },
   "devDependencies": {
+    "@types/react-highlight-words": "^0.20.0",
     "@types/react-window": "^1.8.8",
     "fishery": "^2.2.2",
     "http-proxy-middleware": "^1.3.1",

--- a/frontend/src/components/DashboardListPage/DashboardListPage.tsx
+++ b/frontend/src/components/DashboardListPage/DashboardListPage.tsx
@@ -193,6 +193,7 @@ const DashboardListPage = (props: DashboardListPageProps) => {
             ...dashboardList,
             variants: dashboardList.top_ten_variants,
           }}
+          searchText={""}
           selectedVariants={blankSet}
           taggedGroups={blankTaggedGroups}
           notIncludedVariants={blankSet}

--- a/frontend/src/components/VariantListPage/VariantListVariants.tsx
+++ b/frontend/src/components/VariantListPage/VariantListVariants.tsx
@@ -30,14 +30,16 @@ import {
 } from "../../types";
 
 import MultipleSelect from "../MultipleSelect";
-
 import { DownloadVariantListLink } from "./DownloadVariantList";
 import VariantsTable from "./VariantsTable";
 
 export const combineVariants = (
   variants: Variant[],
-  structuralVariants: any[]
+  structuralVariants: any[] | null
 ) => {
+  if (!structuralVariants || structuralVariants.length === 0) {
+    return variants;
+  }
   const reshapedStructuralVariants = structuralVariants.map((sv: any) => {
     return {
       id: sv.id,
@@ -112,12 +114,11 @@ const VariantListVariants = (props: VariantListVariantsProps) => {
     setPopulationsDisplayedInTable,
   ] = useState<GnomadPopulationId[]>([]);
   const [includeAC0Variants, setIncludeAC0Variants] = useState(false);
+  const [searchText, setSearchText] = useState("");
 
   const { variants, structural_variants } = variantList;
 
-  const renderedVariants = !structural_variants
-    ? variants
-    : combineVariants(variants, structural_variants);
+  const renderedVariants = combineVariants(variants, structural_variants);
 
   type DisplayNames = {
     A: string;
@@ -318,7 +319,13 @@ const VariantListVariants = (props: VariantListVariantsProps) => {
               </DownloadVariantListLink>
             </Box>
           </Box>
-
+          <Box mb={4}>
+            <Input
+              placeholder="Search variants"
+              value={searchText}
+              onChange={(e) => setSearchText(e.target.value)}
+            />
+          </Box>
           <div
             style={{
               width: "100%",
@@ -334,6 +341,7 @@ const VariantListVariants = (props: VariantListVariantsProps) => {
             <VariantsTable
               userCanEdit={userCanEdit || userIsStaff}
               includePopulationFrequencies={populationsDisplayedInTable}
+              searchText={searchText}
               variantList={variantList}
               selectedVariants={selectedVariants}
               taggedGroups={taggedGroups}

--- a/frontend/src/components/VariantListPage/VariantsTable.spec.tsx
+++ b/frontend/src/components/VariantListPage/VariantsTable.spec.tsx
@@ -14,9 +14,11 @@ describe("Variant Table", () => {
       C: { displayName: "", variantList: new Set<VariantId>() },
       D: { displayName: "", variantList: new Set<VariantId>() },
     };
+    const testSearchText = testVariantList.uuid;
     const result = render(
       <VariantsTable
         includePopulationFrequencies={[]}
+        searchText={testSearchText}
         variantList={testVariantList}
         notIncludedVariants={blankSet}
         selectedVariants={new Set(["12-123-A-C", "12-234-A-C"])}

--- a/frontend/src/components/VariantListPage/__snapshots__/VariantsTable.spec.tsx.snap
+++ b/frontend/src/components/VariantListPage/__snapshots__/VariantsTable.spec.tsx.snap
@@ -314,7 +314,13 @@ exports[`Variant Table has no unexpected changes 1`] = `
               rel="noopener noreferrer"
               target="_blank"
             >
-              12-567-A-C
+              <span>
+                <span
+                  class=""
+                >
+                  12-567-A-C
+                </span>
+              </span>
             </a>
           </span>
         </td>
@@ -520,7 +526,13 @@ exports[`Variant Table has no unexpected changes 1`] = `
               rel="noopener noreferrer"
               target="_blank"
             >
-              12-456-A-C
+              <span>
+                <span
+                  class=""
+                >
+                  12-456-A-C
+                </span>
+              </span>
             </a>
           </span>
         </td>
@@ -726,7 +738,13 @@ exports[`Variant Table has no unexpected changes 1`] = `
               rel="noopener noreferrer"
               target="_blank"
             >
-              12-345-A-C
+              <span>
+                <span
+                  class=""
+                >
+                  12-345-A-C
+                </span>
+              </span>
             </a>
           </span>
         </td>
@@ -949,7 +967,13 @@ exports[`Variant Table has no unexpected changes 1`] = `
               rel="noopener noreferrer"
               target="_blank"
             >
-              12-234-A-C
+              <span>
+                <span
+                  class=""
+                >
+                  12-234-A-C
+                </span>
+              </span>
             </a>
           </span>
         </td>
@@ -1198,7 +1222,13 @@ exports[`Variant Table has no unexpected changes 1`] = `
               rel="noopener noreferrer"
               target="_blank"
             >
-              12-123-A-C
+              <span>
+                <span
+                  class=""
+                >
+                  12-123-A-C
+                </span>
+              </span>
             </a>
           </span>
         </td>


### PR DESCRIPTION
Fixes #294
Creates a search feature for the variant table that filters by variant ID. Matching text from the search query is then highlighted within the table and the list scrolls to the first matched variant row to maintain context (similar to the gnomAD "display neighboring variants" search feature) 
![Screenshot 2024-12-10 at 10 40 35 AM](https://github.com/user-attachments/assets/a9f52f99-0282-47d8-93c3-38c4336c7f30)
