### PR TITLE
fix(frontend): address dashboard column display crowding

### DIFF
--- a/frontend/src/components/VariantListPage/VariantsTable.tsx
+++ b/frontend/src/components/VariantListPage/VariantsTable.tsx
@@ -678,7 +678,7 @@ const VariantsTable: FC<VariantsTableProps> = ({
     notIncludedVariants && notIncludedVariants.has(variant.id) ? 1 : 0
   );
 
-  const ROW_HEIGHT = isTopTen ? 35 : 70;
+  const ROW_HEIGHT = isTopTen ? 60 : 70;
   const ITEMS_DISPLAYED = isTopTen ? 10 : 15;
 
   const VariantRow = ({


### PR DESCRIPTION
Fixes #306 (partially)

Addresses the columns such as AC and Clinical significance where text would get cut off if too long or if there are too many flags. 

Regarding the display of the outdated gnomAD version, this will be resolved during winter break when we re-run and update the production dashboard list