### PR TITLE
Try Podman and podman-compose

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,9 +52,9 @@ python data-pipelines/import_clinvar.py --reference-genome GRCh38 --intervals ch
 
 As a shortcut, to prepare data for variants in PCSK9, run `./scripts/prepare_test_data.sh`.
 
-## Running in Docker
+## Running in Podman
 
-This assumes that [BuildKit](https://docs.docker.com/develop/develop-images/build_enhancements/) is enabled.
+This assumes that [Podman](https://podman.io/), and the [compose](https://github.com/containers/podman-compose) plugin, are installed.
 
 - Configure app. Create a `.env` file and fill in values for environment variables.
 
@@ -77,14 +77,14 @@ This assumes that [BuildKit](https://docs.docker.com/develop/develop-images/buil
 - On first run, start database and apply migrations.
 
   ```
-  docker compose up database
-  docker compose run --rm website django-admin migrate
+  podman-compose up database
+  podman-compose run --rm website django-admin migrate
   ```
 
 - Start all services.
 
   ```
-  docker compose up
+  podman compose up
   ```
 
 - On first run, create a user.
@@ -94,7 +94,7 @@ This assumes that [BuildKit](https://docs.docker.com/develop/develop-images/buil
   - Start a REPL.
 
     ```
-    docker compose exec website django-admin shell
+    podman-compose exec website django-admin shell
     ```
 
   - Create a user or activate an existing user.

--- a/compose.yml
+++ b/compose.yml
@@ -20,6 +20,8 @@ services:
   pubsub:
     image: gcr.io/google.com/cloudsdktool/cloud-sdk:latest
     command: gcloud beta emulators pubsub start --host-port=0.0.0.0:8085
+    ports:
+      - "8085:8085"
     environment:
       - PUBSUB_PROJECT_ID=${GCP_PROJECT}
     volumes:
@@ -29,15 +31,21 @@ services:
     build:
       context: .
       dockerfile: pubsub/pubsub.dockerfile
-    command: python setup_subscription.py
+    command: >
+      sh -c "
+      echo 'Waiting for pubsub to be ready...' &&
+      sleep 5 &&
+      python setup_subscription.py"
     environment:
       - PUBSUB_EMULATOR_HOST=pubsub:8085
-      - GCP_PROJECT
+      - GCP_PROJECT=${GCP_PROJECT}
     volumes:
       - ./pubsub/setup_subscription.py:/setup_subscription.py
     depends_on:
-      - pubsub
-      - worker
+      pubsub:
+        condition: service_healthy
+      worker:
+        condition: service_started
   website:
     build:
       context: .
@@ -45,18 +53,18 @@ services:
     command: django-admin runserver website:8080
     environment:
       - DJANGO_SETTINGS_MODULE=website.settings.development
-      - SECRET_KEY
+      - SECRET_KEY=${SECRET_KEY}
       - DB_ENGINE=django.db.backends.postgresql
       - DB_HOST=database
       - DB_PORT=5432
-      - DB_DATABASE
-      - DB_USER
-      - DB_PASSWORD
+      - DB_DATABASE=${DB_DATABASE}
+      - DB_USER=${DB_USER}
+      - DB_PASSWORD=${DB_PASSWORD}
       - ALLOWED_HOSTS=localhost,website
       - PORT=8080
       - PUBSUB_EMULATOR_HOST=pubsub:8085
-      - GCP_PROJECT
-      - GOOGLE_AUTH_CLIENT_ID
+      - GCP_PROJECT=${GCP_PROJECT}
+      - GOOGLE_AUTH_CLIENT_ID=${GOOGLE_AUTH_CLIENT_ID}
     ports:
       - 127.0.0.1:8080:8080
     volumes:
@@ -75,13 +83,13 @@ services:
     command: django-admin runserver worker:8080
     environment:
       - DJANGO_SETTINGS_MODULE=worker.settings.development
-      - SECRET_KEY
+      - SECRET_KEY=${SECRET_KEY}
       - DB_ENGINE=django.db.backends.postgresql
       - DB_HOST=database
       - DB_PORT=5432
-      - DB_DATABASE
-      - DB_USER
-      - DB_PASSWORD
+      - DB_DATABASE=${DB_DATABASE}
+      - DB_USER=${DB_USER}
+      - DB_PASSWORD=${DB_PASSWORD}
       - ALLOWED_HOSTS=localhost,worker
       - PORT=8080
       - GNOMAD_DATA_PATH=/mnt/data

--- a/compose.yml
+++ b/compose.yml
@@ -20,8 +20,6 @@ services:
   pubsub:
     image: gcr.io/google.com/cloudsdktool/cloud-sdk:latest
     command: gcloud beta emulators pubsub start --host-port=0.0.0.0:8085
-    ports:
-      - "8085:8085"
     environment:
       - PUBSUB_PROJECT_ID=${GCP_PROJECT}
     volumes:
@@ -42,10 +40,8 @@ services:
     volumes:
       - ./pubsub/setup_subscription.py:/setup_subscription.py
     depends_on:
-      pubsub:
-        condition: service_healthy
-      worker:
-        condition: service_started
+      - pubsub
+      - worker
   website:
     build:
       context: .

--- a/frontend/frontend-dev.dockerfile
+++ b/frontend/frontend-dev.dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.16.1 as base
+FROM --platform=linux/amd64 node:14.16.1 as base
 
 WORKDIR /app
 

--- a/pubsub/pubsub.dockerfile
+++ b/pubsub/pubsub.dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim
+FROM --platform=linux/amd64 python:3.9-slim
 
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1

--- a/website/website.dockerfile
+++ b/website/website.dockerfile
@@ -1,7 +1,7 @@
 ###############################################################################
 # Frontend build
 ###############################################################################
-FROM node:14.16.1 as frontend
+FROM --platform=linux/amd64 node:14.16.1 as frontend
 
 WORKDIR /app
 
@@ -16,7 +16,7 @@ RUN npm run build
 ###############################################################################
 # Base image
 ###############################################################################
-FROM python:3.9-slim as base
+FROM --platform=linux/amd64 python:3.9-slim as base
 
 RUN useradd --create-home app
 

--- a/worker/worker.dockerfile
+++ b/worker/worker.dockerfile
@@ -1,7 +1,7 @@
 ###############################################################################
 # Base image
 ###############################################################################
-FROM python:3.9-slim as base
+FROM --platform=linux/amd64 python:3.9-slim as base
 
 RUN useradd --create-home app
 


### PR DESCRIPTION
Resolves #318

Adds minor changes to docs to reflect the usage of `podman` over `docker`. This could be avoided by aliasing of `docker` on every developers machine.

Allows development of GeniE locally using only Podman (no Docker). Rather than running `docker compose up` for development, we can now run `podman-compose up`, and have the same effect.