### PR TITLE
Edit parentheses on hover for de novo incidence formula

### DIFF
--- a/frontend/src/components/DashboardListPage/DominantListCharts.tsx
+++ b/frontend/src/components/DashboardListPage/DominantListCharts.tsx
@@ -104,7 +104,7 @@ const DominantListCharts = (props: DominantListChartsProps) => {
             <Flex alignItems="center" mb={2}>
               <Tooltip
                 hasArrow
-                label="((oe_mis_prior − oe_mis) × mu_mis + (oe_lof_prior − oe_lof) × mu_lof) × 2"
+                label="([(oe_mis_prior − oe_mis) × mu_mis]+ [(oe_lof_prior − oe_lof) × mu_lof])× 2"
                 placement="auto-end"
               >
                 <Text fontStyle="italic" fontWeight="bold">


### PR DESCRIPTION
Quick change to the display of the de novo incidence formula when hovering from 

`((oe_mis_prior − oe_mis) × mu_mis + (oe_lof_prior − oe_lof) × mu_lof) × 2
`

to 

`([(oe_mis_prior − oe_mis) × mu_mis]+ [(oe_lof_prior − oe_lof) × mu_lof])× 2
`
<img width="997" alt="Screenshot 2025-06-16 at 6 06 28 PM" src="https://github.com/user-attachments/assets/e44b2d22-9ad8-45c3-a28a-9810f3549156" />
