### PR TITLE
Update source column logic

### DIFF
--- a/worker/src/worker/tasks.py
+++ b/worker/src/worker/tasks.py
@@ -368,10 +368,7 @@ def get_recommended_variants(metadata, transcript):
 
     ds = ds.transmute(
         source=hl.array(
-            [
-                hl.or_missing(ds.include_from_gnomad, "gnomAD"),
-                hl.or_missing(ds.include_from_clinvar, "ClinVar"),
-            ]
+            [hl.if_else(hl.is_defined(ds.include_from_clinvar), "ClinVar", "gnomAD")]
         ).filter(hl.is_defined)
     )
 
@@ -587,10 +584,7 @@ def _process_variant_list(variant_list):
 
     ds = ds.transmute(
         source=hl.array(
-            [
-                hl.or_missing(hl.is_defined(ds.lof), "gnomAD"),
-                hl.or_missing(hl.is_defined(ds.gold_stars), "ClinVar"),
-            ]
+            [hl.if_else(hl.is_defined(ds.gold_stars), "ClinVar", "gnomAD")]
         ).filter(hl.is_defined)
     )
 


### PR DESCRIPTION
Previously, the source field would be converted to 'custom' if the variant came from a variant ID manually input. This meant that when re-processing a list, all the source columns would turn to Custom. Now source column is determined by the presence of a value for the 'lof' field, for gnomAD, and the 'gold_stars' field, for ClinVar.

- Resolves #144 - no longer convert all existing variants (e.g. a reprocessed list) to all "Custom".
- Resolves #332 - only list ClinVar, or gnomAD, never both

---

Screenshot - post re-processing, the source column still retains gnomAD/ClinVar information, where appropriate.
![Screenshot 2025-11-24 at 16 11 58](https://github.com/user-attachments/assets/ac59411a-f0d8-462c-93d7-9852b4fea4c4)