### PR TITLE
Recycle worker after every successful request

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -83,6 +83,7 @@ services:
     build:
       context: .
       dockerfile: worker/worker.dockerfile
+    restart: always
     command: django-admin runserver worker:8080
     environment:
       - DJANGO_SETTINGS_MODULE=worker.settings.development

--- a/worker/src/worker/tasks.py
+++ b/worker/src/worker/tasks.py
@@ -106,9 +106,20 @@ def is_hail_working():
         return False
 
 
-def exit_if_hail_has_failed(sender, **kwargs):  # pylint: disable=unused-argument
-    if not is_hail_working():
-        sys.exit(1)
+def exit_after_job_finished(sender, **kwargs):  # pylint: disable=unused-argument
+    logger.info(
+        "Job finished. Recycling container to clear Java Heap for next request via a new container."
+    )
+
+    # sleep to make sure the WSGI server reponds 204
+    #   before we recycle this container
+    time.sleep(1)
+
+    # Very weird, but just kill at the OS level.
+    #   We know we want this to happen
+    #   sys.exit(0) results in Django trying to
+    #   catch and handle the error.
+    os._exit(0)
 
 
 def variant_id(locus, alleles):


### PR DESCRIPTION
My best guess as to why things fail when there are multiple gene lists submitted in quick succession, is that the Java Heap isn't being properly Garbage Collected by the JVM, because either there's never an opportunity, or that the CPU gets throttled to low when the worker is not actively performing a request.

In general, I don't think hail is particularly good at running multiple jobs one after another -- the resources don't get totally freed.

To try and fix this crashing upon multiple lists submitted in succession, here we make the worker recycle itself after it successfully completes a request. I should probably add some logic to catch any error, and recycle itself in that case too, but for now, this is an attempt to fix the happy path. If this goes OK, I'll add in the logic later.