### PR TITLE
Worker won't accept tasks immediately after finishing work

### DIFF
--- a/worker/src/worker/tasks.py
+++ b/worker/src/worker/tasks.py
@@ -750,6 +750,10 @@ def process_variant_list(uid):
 
         variant_list.save()
 
+    finally:
+        global IS_SHUTTING_DOWN
+        IS_SHUTTING_DOWN = True
+
 
 def handle_event(event):
     try:


### PR DESCRIPTION
Between middleware, etc, there's a small period of time where a worker can still accept a task from the pub/sub, then recycle itself, causing limbo for the task if the retry window closes.

Set the flag immediately after finishing work, to prevent this.