### PR TITLE
Worker doesn't wait on hl.stop() to return

### DIFF
--- a/worker/src/worker/tasks.py
+++ b/worker/src/worker/tasks.py
@@ -132,17 +132,10 @@ def exit_after_job_finished(sender, **kwargs):  # pylint: disable=unused-argumen
     sys.stdout.flush()
     sys.stderr.flush()
 
-    try:
-        logger.info("Stopping hail")
-        hl.stop()
-    except Exception as e:
-        logger.info(f"Exception when stopping Hail!: {e}")
-        pass
-
     # let 20x code get sent from worker, let hl.stop() free resources
     #   from host machine, and let kernel clear ports
     #   I'll gladly take 10 more seconds of wait, to avoid crashes
-    time.sleep(5)
+    time.sleep(1)
 
     # Very weird, but just kill at the OS level.
     #   We know we want this to happen


### PR DESCRIPTION
Worker was hanging on hl.stop() in production, and never recycling itself. Get rid of that call, and rely on the `sleep(5)` before starting Hail in the new worker to allow the OS to clean resources.