### PR TITLE
Don't preload worker with gunicorn

### DIFF
--- a/worker/worker.dockerfile
+++ b/worker/worker.dockerfile
@@ -54,4 +54,4 @@ USER app
 # Run
 ENV DJANGO_SETTINGS_MODULE=worker.settings.base
 
-CMD exec gunicorn --bind :$PORT --log-file - --workers 1 --threads 8 --timeout 120 --preload worker.wsgi
+CMD exec gunicorn --bind :$PORT --log-file - --workers 1 --threads 8 --timeout 120 worker.wsgi


### PR DESCRIPTION
Preload was causing failures to loop, e.g. if a single crash happened, Gunicorn tried to reuse the container, we don't want this, if a container is bad, we want to get rid of it.