### PR TITLE
Add inactive warning to sharing if user has never logged in

### DIFF
--- a/calculator/src/calculator/serializers/variant_list_access_permission_serializer.py
+++ b/calculator/src/calculator/serializers/variant_list_access_permission_serializer.py
@@ -24,12 +24,18 @@ class NewVariantListAccessPermissionSerializer(ModelSerializer):
 
 class VariantListAccessPermissionSerializer(ModelSerializer):
     user = serializers.SlugRelatedField(slug_field="username", read_only=True)
+    user_ever_logged_in = serializers.SerializerMethodField()
 
     level = ChoiceField(choices=VariantListAccessPermission.Level.choices)
 
     class Meta:
         model = VariantListAccessPermission
 
-        fields = ["uuid", "user", "level"]
+        fields = ["uuid", "user", "level", "user_ever_logged_in"]
 
         read_only_fields = [f for f in fields if f not in ("level",)]
+
+    def get_user_ever_logged_in(self, obj):
+        if obj.user:
+            return obj.user.last_login is not None
+        return False

--- a/frontend/src/components/VariantListPage/VariantListPage.tsx
+++ b/frontend/src/components/VariantListPage/VariantListPage.tsx
@@ -727,6 +727,20 @@ const VariantListPage = (props: VariantListPageProps) => {
                   >
                     <Badge>{accessPermission.level}</Badge>
                   </Tooltip>
+                  {accessPermission.user_ever_logged_in === false && (
+                    <>
+                      {" "}
+                      <Tooltip
+                        hasArrow
+                        label={
+                          "A user with this email has never signed in to GeniE. Is the email address correct?"
+                        }
+                        placement="right"
+                      >
+                        <Badge colorScheme="yellow">{"User inactive"}</Badge>
+                      </Tooltip>
+                    </>
+                  )}
                 </ListItem>
               );
             })}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -144,6 +144,7 @@ interface VariantListAccessPermission {
   uuid: string;
   user: string;
   level: VariantListAccessLevel;
+  user_ever_logged_in: boolean;
 }
 
 export interface VariantList {


### PR DESCRIPTION
Currently, when someone adds an email as a collaborator, GeniE creates a stub of a user account that holds the permissions. Then, when the user logs in, they already have the permissions.

This adds a badge for if the user that the list has been shared with has never signed in, and a tooltip info message about making sure the email is correct.

---

![Screenshot 2026-03-27 at 14 12 42](https://github.com/user-attachments/assets/a1164fc7-b444-42a8-a4a0-3b142aadd222)
