### PR TITLE
Allow signing in via google again

### DIFF
--- a/website/src/website/settings/base.py
+++ b/website/src/website/settings/base.py
@@ -156,6 +156,9 @@ SECURE_BROWSER_XSS_FILTER = True
 
 SECURE_SSL_REDIRECT = True
 
+# allow Google auth popup to work in production
+SECURE_CROSS_ORIGIN_OPENER_POLICY = "same-origin-allow-popups"
+
 if os.getenv("SECURE_PROXY_SSL_HEADER"):
     SECURE_PROXY_SSL_HEADER = tuple(os.environ["SECURE_PROXY_SSL_HEADER"].split(":"))
 


### PR DESCRIPTION
Django 3 -> 4 update made default security stricter.

Add a header to allow the Google Auth popup to send data back to main window, fixing the google auth login.